### PR TITLE
Update Button.lua

### DIFF
--- a/ButtonForge/Button.lua
+++ b/ButtonForge/Button.lua
@@ -1647,8 +1647,8 @@ function Button:UpdateTextCountSpell()
 		self.WCount:SetText(count);
 		return;
 	end
-	local charges = GetSpellCharges(self.SpellNameRank);
-	if (charges ~= nil) then
+	local charges, maxCharges = GetSpellCharges(self.SpellNameRank);
+	if (charges ~= nil and maxCharges ~= 1) then
 		self.WCount:SetText(charges);
 		return;
 	end


### PR DESCRIPTION
Spells that have no need to show charges (because they only have 1 max charge) won't show charges with this check to maxCharges